### PR TITLE
Fix while navigating between languages issues in Azerbaijani

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -44,6 +44,16 @@ const Header = ({location}: {location: Location}) => (
       },
     }}>
     <ContainerWrapper>
+      {typeof window === 'undefined'
+        ? ''
+        : typeof localStorage === 'undefined'
+        ? ''
+        : window.location.pathname != '/languages'
+        ? localStorage.setItem(
+            'last_visited_path',
+            window.location.pathname + window.location.hash,
+          )
+        : ''}
       <Container>
         <div style={{position: 'relative'}}>
           <Banner />

--- a/src/components/MarkdownPage/MarkdownPage.js
+++ b/src/components/MarkdownPage/MarkdownPage.js
@@ -5,164 +5,165 @@
  * @flow
  */
 
-import Container from 'components/Container';
-import Flex from 'components/Flex';
-import MarkdownHeader from 'components/MarkdownHeader';
-import NavigationFooter from 'templates/components/NavigationFooter';
-// $FlowFixMe Update Flow
-import React from 'react';
-import StickyResponsiveSidebar from 'components/StickyResponsiveSidebar';
-import TitleAndMetaTags from 'components/TitleAndMetaTags';
-import FeedbackForm from 'components/FeedbackForm';
-import findSectionForPath from 'utils/findSectionForPath';
-import toCommaSeparatedList from 'utils/toCommaSeparatedList';
-import {sharedStyles} from 'theme';
-import createCanonicalUrl from 'utils/createCanonicalUrl';
-import {colors, media} from 'theme';
-
-import type {Node} from 'types';
-
-type Props = {
-  authors: Array<string>,
-  createLink: Function, // TODO: Add better flow type once we Flow-type createLink
-  date?: string,
-  enableScrollSync?: boolean,
-  ogDescription: string,
-  location: Location,
-  markdownRemark: Node,
-  sectionList: Array<Object>, // TODO: Add better flow type once we have the Section component
-  titlePostfix: string,
-};
-
-const getPageById = (sectionList: Array<Object>, templateFile: ?string) => {
-  if (!templateFile) {
-    return null;
-  }
-
-  const sectionItems = sectionList.map(section => section.items);
-  const flattenedSectionItems = [].concat.apply([], sectionItems);
-  const linkId = templateFile.replace('.html', '');
-
-  return flattenedSectionItems.find(item => item.id === linkId);
-};
-
-const MarkdownPage = ({
-  authors = [],
-  createLink,
-  date,
-  enableScrollSync,
-  ogDescription,
-  location,
-  markdownRemark,
-  sectionList,
-  titlePostfix = '',
-}: Props) => {
-  const hasAuthors = authors.length > 0;
-  const titlePrefix = markdownRemark.frontmatter.title || '';
-
-  const prev = getPageById(sectionList, markdownRemark.frontmatter.prev);
-  const next = getPageById(sectionList, markdownRemark.frontmatter.next);
-
-  return (
-    <Flex
-      direction="column"
-      grow="1"
-      shrink="0"
-      halign="stretch"
-      css={{
-        width: '100%',
-        flex: '1 0 auto',
-        position: 'relative',
-        zIndex: 0,
-        '& h1, & h2, & h3, & h4, & h5, & h6': {
-          scrollMarginTop: 'var(--banner-height-normal)',
-          [media.lessThan('small')]: {
-            scrollMarginTop: 'var(--banner-height-small)',
-          },
-        },
-      }}>
-      <TitleAndMetaTags
-        ogDescription={ogDescription}
-        ogType="article"
-        canonicalUrl={createCanonicalUrl(markdownRemark.fields.slug)}
-        title={`${titlePrefix}${titlePostfix}`}
-      />
-      <div css={{flex: '1 0 auto'}}>
-        <Container>
-          <div css={sharedStyles.articleLayout.container}>
-            <Flex type="article" direction="column" grow="1" halign="stretch">
-              <MarkdownHeader title={titlePrefix} />
-
-              {(date || hasAuthors) && (
-                <div css={{marginTop: 15}}>
-                  {date}{' '}
-                  {hasAuthors && (
-                    <span>
-                      by{' '}
-                      {toCommaSeparatedList(authors, author => (
-                        <a
-                          css={sharedStyles.link}
-                          href={author.frontmatter.url}
-                          key={author.frontmatter.name}>
-                          {author.frontmatter.name}
-                        </a>
-                      ))}
-                    </span>
-                  )}
-                </div>
-              )}
-
-              <div css={sharedStyles.articleLayout.content}>
-                <div
-                  css={[sharedStyles.markdown]}
-                  dangerouslySetInnerHTML={{__html: markdownRemark.html}}
-                />
-
-                {markdownRemark.fields.path && (
-                  <div css={{marginTop: 80}}>
-                    <span
-                      css={{
-                        whiteSpace: 'nowrap',
-                        paddingBottom: '1em',
-                        marginRight: '36px',
-                        display: 'inline-block',
-                        color: colors.subtle,
-                      }}>
-                      <FeedbackForm />
-                    </span>
-                    <a
-                      css={sharedStyles.articleLayout.editLink}
-                      href={`https://github.com/reactjs/reactjs.org/tree/master/${
-                        markdownRemark.fields.path
-                      }`}>
-                      Bu səhifəni redaktə edin
-                    </a>
-                  </div>
-                )}
-              </div>
-            </Flex>
-
-            <div css={sharedStyles.articleLayout.sidebar}>
-              <StickyResponsiveSidebar
-                enableScrollSync={enableScrollSync}
-                createLink={createLink}
-                defaultActiveSection={findSectionForPath(
-                  location.pathname,
-                  sectionList,
-                )}
-                location={location}
-                sectionList={sectionList}
-              />
-            </div>
-          </div>
-        </Container>
-      </div>
-
-      {(next || prev) && (
-        <NavigationFooter location={location} next={next} prev={prev} />
-      )}
-    </Flex>
-  );
-};
-
-export default MarkdownPage;
+ import Container from 'components/Container';
+ import Flex from 'components/Flex';
+ import MarkdownHeader from 'components/MarkdownHeader';
+ import NavigationFooter from 'templates/components/NavigationFooter';
+ // $FlowFixMe Update Flow
+ import React from 'react';
+ import StickyResponsiveSidebar from 'components/StickyResponsiveSidebar';
+ import TitleAndMetaTags from 'components/TitleAndMetaTags';
+ import FeedbackForm from 'components/FeedbackForm';
+ import findSectionForPath from 'utils/findSectionForPath';
+ import toCommaSeparatedList from 'utils/toCommaSeparatedList';
+ import {sharedStyles} from 'theme';
+ import createCanonicalUrl from 'utils/createCanonicalUrl';
+ import {colors, media} from 'theme';
+ 
+ import type {Node} from 'types';
+ 
+ type Props = {
+   authors: Array<string>,
+   createLink: Function, // TODO: Add better flow type once we Flow-type createLink
+   date?: string,
+   enableScrollSync?: boolean,
+   ogDescription: string,
+   location: Location,
+   markdownRemark: Node,
+   sectionList: Array<Object>, // TODO: Add better flow type once we have the Section component
+   titlePostfix: string,
+ };
+ 
+ const getPageById = (sectionList: Array<Object>, templateFile: ?string) => {
+   if (!templateFile) {
+     return null;
+   }
+ 
+   const sectionItems = sectionList.map(section => section.items);
+   const flattenedSectionItems = [].concat.apply([], sectionItems);
+   const linkId = templateFile.replace('.html', '');
+ 
+   return flattenedSectionItems.find(item => item.id === linkId);
+ };
+ 
+ const MarkdownPage = ({
+   authors = [],
+   createLink,
+   date,
+   enableScrollSync,
+   ogDescription,
+   location,
+   markdownRemark,
+   sectionList,
+   titlePostfix = '',
+ }: Props) => {
+   const hasAuthors = authors.length > 0;
+   const titlePrefix = markdownRemark.frontmatter.title || '';
+ 
+   const prev = getPageById(sectionList, markdownRemark.frontmatter.prev);
+   const next = getPageById(sectionList, markdownRemark.frontmatter.next);
+ 
+   return (
+     <Flex
+       direction="column"
+       grow="1"
+       shrink="0"
+       halign="stretch"
+       css={{
+         width: '100%',
+         flex: '1 0 auto',
+         position: 'relative',
+         zIndex: 0,
+         '& h1, & h2, & h3, & h4, & h5, & h6': {
+           scrollMarginTop: 'var(--banner-height-normal)',
+           [media.lessThan('small')]: {
+             scrollMarginTop: 'var(--banner-height-small)',
+           },
+         },
+       }}>
+       <TitleAndMetaTags
+         ogDescription={ogDescription}
+         ogType="article"
+         canonicalUrl={createCanonicalUrl(markdownRemark.fields.slug)}
+         title={`${titlePrefix}${titlePostfix}`}
+       />
+       <div css={{flex: '1 0 auto'}}>
+         <Container>
+           <div css={sharedStyles.articleLayout.container}>
+             <Flex type="article" direction="column" grow="1" halign="stretch">
+               <MarkdownHeader title={titlePrefix} />
+ 
+               {(date || hasAuthors) && (
+                 <div css={{marginTop: 15}}>
+                   {date}{' '}
+                   {hasAuthors && (
+                     <span>
+                       by{' '}
+                       {toCommaSeparatedList(authors, author => (
+                         <a
+                           css={sharedStyles.link}
+                           href={author.frontmatter.url}
+                           key={author.frontmatter.name}>
+                           {author.frontmatter.name}
+                         </a>
+                       ))}
+                     </span>
+                   )}
+                 </div>
+               )}
+ 
+               <div css={sharedStyles.articleLayout.content}>
+                 <div
+                   css={[sharedStyles.markdown]}
+                   dangerouslySetInnerHTML={{__html: markdownRemark.html}}
+                 />
+ 
+                 {markdownRemark.fields.path && (
+                   <div css={{marginTop: 80}}>
+                     <span
+                       css={{
+                         whiteSpace: 'nowrap',
+                         paddingBottom: '1em',
+                         marginRight: '36px',
+                         display: 'inline-block',
+                         color: colors.subtle,
+                       }}>
+                       <FeedbackForm />
+                     </span>
+                     <a
+                       css={sharedStyles.articleLayout.editLink}
+                       href={`https://github.com/reactjs/reactjs.org/tree/master/${
+                         markdownRemark.fields.path
+                       }`}>
+                       Bu səhifəni redaktə edin
+                     </a>
+                   </div>
+                 )}
+               </div>
+             </Flex>
+ 
+             <div css={sharedStyles.articleLayout.sidebar}>
+               <StickyResponsiveSidebar
+                 enableScrollSync={enableScrollSync}
+                 createLink={createLink}
+                 defaultActiveSection={findSectionForPath(
+                   location.pathname,
+                   sectionList,
+                 )}
+                 location={location}
+                 sectionList={sectionList}
+               />
+             </div>
+           </div>
+         </Container>
+       </div>
+ 
+       {(next || prev) && (
+         <NavigationFooter location={location} next={next} prev={prev} />
+       )}
+     </Flex>
+   );
+ };
+ 
+ export default MarkdownPage;
+ 

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -139,7 +139,16 @@ const Language = ({code, name, status, translatedName}) => {
         {status === 0 && translatedName}
         {status > 0 && (
           <a
-            href={`https://${prefix}reactjs.org/`}
+            href={
+              'https://' +
+              prefix +
+              'reactjs.org' +
+              (typeof localStorage === undefined
+                ? ''
+                : typeof localStorage === 'undefined'
+                ? ''
+                : String(localStorage.getItem('last_visited_path')))
+            }
             rel="nofollow"
             lang={code}
             hrefLang={code}>


### PR DESCRIPTION
Users were having difficulties while navigating between different language. Issue in explained better here https://github.com/reactjs/reactjs.org/issues/3760

### About Solution
We would have to store last visited pathname right before the language page is visited in local storage and add the pathname when the language is changed.
For example -
A visted https://reactjs.org/docs/getting-started.html#try-react .
At this point the pathname would be "/docs/getting-started.html#try-react"
Now A has changed the language to Italian. This will add the pathname stored in the local storage to the main italian link which will become "https://it.reactjs.org/docs/getting-started.html#try-react". And A will be directed to same.]
Since different languages have different repository for each. The code has to be added in all the repositories with no change required. Currently i am adding the changes to the languages other than In Progress and Need Contributors sections. Which makes the remaining 17 languages.This is one of the repository.
I found this way efficient than others. I have made pull request in each of the repositories. Please let me know if any change is required. I would be happy to take any suggestion.

### Issue Details
Issue Title- When changing languages, user is sent to the home page instead of the current article
Issue number - 3760